### PR TITLE
Update YouTube link to @Bluezz360 channel

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -159,7 +159,7 @@
                     <img src="./assets/svg/photo_camera.svg" alt="image">
                 </span>
             </a>
-            <a href="https://www.youtube.com/@blue.thelocalguide?themeRefresh=1" target="_blank" title="YouTube">
+            <a href="https://www.youtube.com/@Bluezz360" target="_blank" title="YouTube">
                 <span class="sr-only">Subscribe to our YouTube channel</span>
                 <span class="material-icons" aria-hidden="true">
                     <img src="./assets/svg/youtube.svg" alt="image">

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
                     <img src="./assets/svg/photo_camera.svg" alt="image">
                 </span>
             </a>
-            <a href="https://www.youtube.com/@blue.thelocalguide?themeRefresh=1" target="_blank" title="YouTube">
+            <a href="https://www.youtube.com/@Bluezz360" target="_blank" title="YouTube">
                 <span class="sr-only">Subscribe to our YouTube channel</span>
                 <span class="material-icons" aria-hidden="true">
                     <img src="./assets/svg/youtube.svg" alt="image">

--- a/pricing.html
+++ b/pricing.html
@@ -410,7 +410,7 @@
                     <img src="./assets/svg/photo_camera.svg" alt="image">
                 </span>
             </a>
-            <a href="https://www.youtube.com/@blue.thelocalguide?themeRefresh=1" target="_blank" title="YouTube">
+            <a href="https://www.youtube.com/@Bluezz360" target="_blank" title="YouTube">
                 <span class="sr-only">Subscribe to our YouTube channel</span>
                 <span class="material-icons" aria-hidden="true">
                     <img src="./assets/svg/youtube.svg" alt="image">


### PR DESCRIPTION
The footer social links across the site pointed to an old YouTube handle (@blue.thelocalguide). Update all three pages to the current channel @Bluezz360 and drop the stale ?themeRefresh=1 query param.